### PR TITLE
Fix "invalid version" error on bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "normalize-less",
-  "version": "0.1",
+  "version": "0.0.2",
   "main": "normalize.less",
   "authors": [
     "Richard Bailey <additive.inverse@gmail.com>"


### PR DESCRIPTION
When attempting to install this via bower registry (`bower install normalize-less`) I was getting the following error:

`- normalize-less invalid version: 0.1`

I converted the version in `bower.json` to use [semantic versioning](http://semver.org/), bumped the patch version, and tagged as `v0.0.2` on my forked repo to fix.

To integrate the changes correctly so that it will able to be checked out via the bower registry you would need to:
1. Merge the changes into the `master` branch
2. Create a `v0.0.2` tag

Hoping this will help out anyone else trying to check out via the bower registry!

Thanks.
